### PR TITLE
Implement light transition halting feature

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -164,5 +164,15 @@ template<typename... Ts> class AddressableSet : public Action<Ts...> {
   LightState *parent_;
 };
 
+template<typename... Ts> class HaltTransitionAction : public Action<Ts...> {
+ public:
+  explicit HaltTransitionAction(LightState *state) : state_(state) {}
+
+  void play(Ts... x) override { this->state_->halt_transition(); }
+
+ protected:
+  LightState *state_;
+};
+
 }  // namespace light
 }  // namespace esphome

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -5,7 +5,8 @@ from esphome.const import CONF_ID, CONF_TRANSITION_LENGTH, CONF_STATE, CONF_FLAS
     CONF_EFFECT, CONF_BRIGHTNESS, CONF_RED, CONF_GREEN, CONF_BLUE, CONF_WHITE, \
     CONF_COLOR_TEMPERATURE, CONF_RANGE_FROM, CONF_RANGE_TO
 from .types import DimRelativeAction, ToggleAction, LightState, LightControlAction, \
-    AddressableLightState, AddressableSet, LightIsOnCondition, LightIsOffCondition
+    AddressableLightState, AddressableSet, LightIsOnCondition, LightIsOffCondition, \
+    HaltTransitionAction
 
 
 @automation.register_action('light.toggle', ToggleAction, automation.maybe_simple_id({
@@ -145,6 +146,15 @@ def light_addressable_set_to_code(config, action_id, template_arg, args):
         templ = yield cg.templatable(config[CONF_WHITE], args, cg.uint8, to_exp=rgbw_to_exp)
         cg.add(var.set_white(templ))
     yield var
+
+
+@automation.register_action('light.halt_transition', HaltTransitionAction,
+                            automation.maybe_simple_id({
+                                cv.Required(CONF_ID): cv.use_id(LightState),
+                            }))
+def light_halt_transition_to_code(config, action_id, template_arg, args):
+    paren = yield cg.get_variable(config[CONF_ID])
+    yield cg.new_Pvariable(action_id, template_arg, paren)
 
 
 @automation.register_condition('light.is_on', LightIsOnCondition,

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -755,6 +755,18 @@ void LightState::current_values_as_cwww(float *cold_white, float *warm_white, bo
   this->current_values.as_cwww(traits.get_min_mireds(), traits.get_max_mireds(), cold_white, warm_white,
                                this->gamma_correct_, constant_brightness);
 }
+
+void LightState::halt_transition() {
+  if (this->transformer_ == nullptr || !this->transformer_->is_transition())
+    return;
+  // Apply current intermediate values and stop the transformer
+  this->current_values = this->transformer_->get_values();
+  this->remote_values = this->current_values;
+  this->transformer_.reset();
+  this->next_write_ = true;
+  this->remote_values_callback_.call();
+  this->target_state_reached_callback_.call();
+}
 void LightState::add_new_remote_values_callback(std::function<void()> &&send_callback) {
   this->remote_values_callback_.add(std::move(send_callback));
 }

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -282,6 +282,11 @@ class LightState : public Nameable, public Component {
 
   void current_values_as_cwww(float *cold_white, float *warm_white, bool constant_brightness = false);
 
+  /// Halt the current transition if one is active and apply the intermediate
+  /// values immediately. Remote values will be updated to match the current
+  /// partial state.
+  void halt_transition();
+
  protected:
   friend LightOutput;
   friend LightCall;

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -20,6 +20,7 @@ DimRelativeAction = light_ns.class_('DimRelativeAction', automation.Action)
 AddressableSet = light_ns.class_('AddressableSet', automation.Action)
 LightIsOnCondition = light_ns.class_('LightIsOnCondition', automation.Condition)
 LightIsOffCondition = light_ns.class_('LightIsOffCondition', automation.Condition)
+HaltTransitionAction = light_ns.class_('HaltTransitionAction', automation.Action)
 
 # Triggers
 LightTurnOnTrigger = light_ns.class_('LightTurnOnTrigger', automation.Trigger.template())


### PR DESCRIPTION
## Summary
- add `halt_transition` helper in LightState
- expose new HaltTransitionAction automation action
- allow halting a transition mid-way and keep current partial values

## Testing
- `script/quicklint` *(fails: Git not configured)*
- `script/test` *(fails: esphome command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b33a3eeb08331bfa6cf6f43e54bb2