### PR TITLE
Fix coefficient key name in combination sensor

### DIFF
--- a/esphome/components/combination/combination.cpp
+++ b/esphome/components/combination/combination.cpp
@@ -126,7 +126,7 @@ void LinearCombinationComponent::setup() {
 }
 
 void LinearCombinationComponent::handle_new_value(float value) {
-  // Multiplies each sensor state by a configured coeffecient and then sums
+  // Multiplies each sensor state by a configured coefficient and then sums
 
   if (!std::isfinite(value))
     return;

--- a/esphome/components/combination/sensor.py
+++ b/esphome/components/combination/sensor.py
@@ -47,6 +47,7 @@ SumCombinationComponent = combination_ns.class_(
     "SumCombinationComponent", cg.Component, sensor.Sensor
 )
 
+CONF_COEFFICIENT = "coefficient"
 CONF_COEFFECIENT = "coeffecient"
 CONF_ERROR = "error"
 CONF_KALMAN = "kalman"
@@ -68,11 +69,14 @@ KALMAN_SOURCE_SCHEMA = cv.Schema(
     }
 )
 
-LINEAR_SOURCE_SCHEMA = cv.Schema(
-    {
-        cv.Required(CONF_SOURCE): cv.use_id(sensor.Sensor),
-        cv.Required(CONF_COEFFECIENT): cv.templatable(cv.float_),
-    }
+LINEAR_SOURCE_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Required(CONF_SOURCE): cv.use_id(sensor.Sensor),
+            cv.Required(CONF_COEFFICIENT): cv.templatable(cv.float_),
+        }
+    ),
+    cv.rename_key(CONF_COEFFECIENT, CONF_COEFFICIENT),
 )
 
 SENSOR_ONLY_SOURCE_SCHEMA = cv.Schema(
@@ -162,12 +166,12 @@ async def to_code(config):
             )
             cg.add(var.add_source(source, error))
         elif config[CONF_TYPE] == CONF_LINEAR:
-            coeffecient = await cg.templatable(
-                source_conf[CONF_COEFFECIENT],
+            coefficient = await cg.templatable(
+                source_conf[CONF_COEFFICIENT],
                 [(float, "x")],
                 cg.float_,
             )
-            cg.add(var.add_source(source, coeffecient))
+            cg.add(var.add_source(source, coefficient))
         else:
             cg.add(var.add_source(source))
 

--- a/tests/components/combination/common.yaml
+++ b/tests/components/combination/common.yaml
@@ -29,9 +29,9 @@ sensor:
     name: Linearly combined temperatures
     sources:
       - source: template_temperature1
-        coeffecient: !lambda "return 0.4 + std::abs(x - 25) * 0.023;"
+        coefficient: !lambda "return 0.4 + std::abs(x - 25) * 0.023;"
       - source: template_temperature2
-        coeffecient: 1.5
+        coefficient: 1.5
   - platform: combination
     type: max
     name: Max of combined temperatures


### PR DESCRIPTION
## Summary
- rename `CONF_COEFFECIENT` to `CONF_COEFFICIENT`
- update LinearCombination schema and code accordingly
- keep backward compatibility with `cv.rename_key`
- fix typo in C++ comment
- adjust combination tests to use the new key

## Testing
- `pytest tests/unit_tests -k esphome_version -vv`
- `pytest tests/unit_tests/test_core.py::test_is_approximately_integer__in_range -q`
- `script/quicklint` *(fails: Git not configured)*

------
https://chatgpt.com/codex/tasks/task_e_686f05240f9483248f053b64ff749aec