### PR TITLE
Add smooth dimming actions

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -104,6 +104,29 @@ template<typename... Ts> class DimRelativeAction : public Action<Ts...> {
   LimitMode limit_mode_{LimitMode::CLAMP};
 };
 
+template<typename... Ts> class StartDimmingAction : public Action<Ts...> {
+ public:
+  explicit StartDimmingAction(LightState *parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(DimmingDirection, direction)
+  TEMPLATABLE_VALUE(float, speed)
+
+  void play(Ts... x) override { this->parent_->start_dimming(this->direction_.value(x...), this->speed_.value(x...)); }
+
+ protected:
+  LightState *parent_;
+};
+
+template<typename... Ts> class StopDimmingAction : public Action<Ts...> {
+ public:
+  explicit StopDimmingAction(LightState *parent) : parent_(parent) {}
+
+  void play(Ts... x) override { this->parent_->stop_dimming(); }
+
+ protected:
+  LightState *parent_;
+};
+
 template<typename... Ts> class LightIsOnCondition : public Condition<Ts...> {
  public:
   explicit LightIsOnCondition(LightState *state) : state_(state) {}

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -27,15 +27,19 @@ from esphome.const import (
 
 from .types import (
     COLOR_MODES,
+    DIMMING_DIRECTIONS,
     LIMIT_MODES,
     AddressableLightState,
     AddressableSet,
     ColorMode,
+    DimmingDirection,
     DimRelativeAction,
     LightControlAction,
     LightIsOffCondition,
     LightIsOnCondition,
     LightState,
+    StartDimmingAction,
+    StopDimmingAction,
     ToggleAction,
 )
 
@@ -191,6 +195,23 @@ LIGHT_DIM_RELATIVE_ACTION_SCHEMA = cv.Schema(
     }
 )
 
+CONF_DIRECTION = "direction"
+CONF_SPEED = "speed"
+
+LIGHT_START_DIMMING_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.use_id(LightState),
+        cv.Required(CONF_DIRECTION): cv.templatable(
+            cv.enum(DIMMING_DIRECTIONS, upper=True)
+        ),
+        cv.Required(CONF_SPEED): cv.templatable(cv.positive_float),
+    }
+)
+
+LIGHT_STOP_DIMMING_SCHEMA = automation.maybe_simple_id(
+    {cv.Required(CONF_ID): cv.use_id(LightState)}
+)
+
 
 @automation.register_action(
     "light.dim_relative", DimRelativeAction, LIGHT_DIM_RELATIVE_ACTION_SCHEMA
@@ -210,6 +231,28 @@ async def light_dim_relative_to_code(config, action_id, template_arg, args):
             )
         )
         cg.add(var.set_limit_mode(conf[CONF_LIMIT_MODE]))
+    return var
+
+
+@automation.register_action(
+    "light.start_dimming", StartDimmingAction, LIGHT_START_DIMMING_SCHEMA
+)
+async def light_start_dimming_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    direction = await cg.templatable(config[CONF_DIRECTION], args, DimmingDirection)
+    cg.add(var.set_direction(direction))
+    speed = await cg.templatable(config[CONF_SPEED], args, cg.float_)
+    cg.add(var.set_speed(speed))
+    return var
+
+
+@automation.register_action(
+    "light.stop_dimming", StopDimmingAction, LIGHT_STOP_DIMMING_SCHEMA
+)
+async def light_stop_dimming_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
     return var
 
 

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -296,5 +296,23 @@ void LightState::save_remote_values_() {
   this->rtc_.save(&saved);
 }
 
+void LightState::start_dimming(DimmingDirection direction, float speed) {
+  this->stop_effect_();
+  this->transformer_ = make_unique<LightDimmingTransformer>(*this, direction, speed);
+  this->transformer_->setup(this->current_values, this->current_values, 0);
+}
+
+void LightState::stop_dimming() {
+  if (this->transformer_ != nullptr) {
+    this->current_values = this->transformer_->get_target_values();
+    this->remote_values = this->transformer_->get_target_values();
+    this->transformer_->stop();
+    this->transformer_ = nullptr;
+    this->is_transformer_active_ = false;
+    this->publish_state();
+    this->target_state_reached_callback_.call();
+  }
+}
+
 }  // namespace light
 }  // namespace esphome

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -28,6 +28,8 @@ enum LightRestoreMode : uint8_t {
   LIGHT_RESTORE_AND_ON,
 };
 
+enum class DimmingDirection : uint8_t { UP = 0, DOWN = 1 };
+
 struct LightStateRTCState {
   LightStateRTCState(ColorMode color_mode, bool state, float brightness, float color_brightness, float red, float green,
                      float blue, float white, float color_temp, float cold_white, float warm_white)
@@ -74,6 +76,11 @@ class LightState : public EntityBase, public Component {
   LightCall turn_off();
   LightCall toggle();
   LightCall make_call();
+
+  /// Start continuously dimming the light in the given direction at the provided speed (0.0-1.0 per second).
+  void start_dimming(DimmingDirection direction, float speed);
+  /// Stop any ongoing dimming operation and keep the current brightness level.
+  void stop_dimming();
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)

--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -122,5 +122,44 @@ class LightFlashTransformer : public LightTransformer {
   bool begun_lightstate_restore_;
 };
 
+class LightDimmingTransformer : public LightTransformer {
+ public:
+  LightDimmingTransformer(LightState &state, DimmingDirection direction, float speed)
+      : state_(state), direction_(direction), speed_(speed) {}
+
+  void start() override { this->last_update_ = millis(); }
+
+  optional<LightColorValues> apply() override {
+    uint32_t now = millis();
+    float dt = (now - this->last_update_) / 1000.0f;
+    this->last_update_ = now;
+    float cur;
+    this->state_.current_values.as_brightness(&cur);
+    float delta = this->speed_ * dt * (this->direction_ == DimmingDirection::UP ? 1.0f : -1.0f);
+    cur = clamp(cur + delta, 0.0f, 1.0f);
+    this->target_values_ = this->state_.current_values;
+    this->target_values_.set_brightness(cur);
+    this->target_values_.set_state(cur > 0.0f);
+    this->state_.remote_values = this->target_values_;
+    this->state_.publish_state();
+    return this->target_values_;
+  }
+
+  bool is_finished() override {
+    float cur;
+    this->state_.current_values.as_brightness(&cur);
+    if (this->direction_ == DimmingDirection::UP)
+      return cur >= 1.0f;
+    else
+      return cur <= 0.0f;
+  }
+
+ protected:
+  LightState &state_;
+  DimmingDirection direction_;
+  float speed_;
+  uint32_t last_update_{0};
+};
+
 }  // namespace light
 }  // namespace esphome

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -35,11 +35,20 @@ LIMIT_MODES = {
     "DO_NOTHING": LimitMode.DO_NOTHING,
 }
 
+# Dimming direction
+DimmingDirection = light_ns.enum("DimmingDirection", is_class=True)
+DIMMING_DIRECTIONS = {
+    "UP": DimmingDirection.UP,
+    "DOWN": DimmingDirection.DOWN,
+}
+
 # Actions
 ToggleAction = light_ns.class_("ToggleAction", automation.Action)
 LightControlAction = light_ns.class_("LightControlAction", automation.Action)
 DimRelativeAction = light_ns.class_("DimRelativeAction", automation.Action)
 AddressableSet = light_ns.class_("AddressableSet", automation.Action)
+StartDimmingAction = light_ns.class_("StartDimmingAction", automation.Action)
+StopDimmingAction = light_ns.class_("StopDimmingAction", automation.Action)
 LightIsOnCondition = light_ns.class_("LightIsOnCondition", automation.Condition)
 LightIsOffCondition = light_ns.class_("LightIsOffCondition", automation.Condition)
 

--- a/tests/components/light/common.yaml
+++ b/tests/components/light/common.yaml
@@ -17,6 +17,11 @@ esphome:
           relative_brightness: 5%
           brightness_limits:
             max_brightness: 90%
+      - light.start_dimming:
+          id: test_monochromatic_light
+          direction: up
+          speed: 0.1
+      - light.stop_dimming: test_monochromatic_light
 
 light:
   - platform: binary


### PR DESCRIPTION
## Summary
- add `start_dimming`/`stop_dimming` actions to light automation
- implement `LightDimmingTransformer` and helpers
- expose dimming direction enum and methods
- test new light actions

## Testing
- `pre-commit run --files esphome/components/light/light_state.h esphome/components/light/light_state.cpp esphome/components/light/transformers.h esphome/components/light/automation.h esphome/components/light/types.py esphome/components/light/automation.py tests/components/light/common.yaml`
- `pytest -k light -q` *(fails: ModuleNotFoundError: No module named 'aioesphomeapi')*

------
https://chatgpt.com/codex/tasks/task_e_6871832ffa8c83248992d16c386f8bb5