### PR TITLE
Add light dimming start/stop action

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -104,6 +104,33 @@ template<typename... Ts> class DimRelativeAction : public Action<Ts...> {
   LimitMode limit_mode_{LimitMode::CLAMP};
 };
 
+template<typename... Ts> class StartDimmingAction : public Action<Ts...> {
+ public:
+  explicit StartDimmingAction(LightState *parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(float, speed)
+  TEMPLATABLE_VALUE(DimmingDirection, direction)
+
+  void play(Ts... x) override {
+    float spd = this->speed_.value(x...);
+    auto dir = this->direction_.value_or(x..., DimmingDirection::DIM_UP);
+    this->parent_->start_dimming(spd, dir);
+  }
+
+ protected:
+  LightState *parent_;
+};
+
+template<typename... Ts> class StopDimmingAction : public Action<Ts...> {
+ public:
+  explicit StopDimmingAction(LightState *parent) : parent_(parent) {}
+
+  void play(Ts... x) override { this->parent_->stop_dimming(); }
+
+ protected:
+  LightState *parent_;
+};
+
 template<typename... Ts> class LightIsOnCondition : public Condition<Ts...> {
  public:
   explicit LightIsOnCondition(LightState *state) : state_(state) {}

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -27,6 +27,7 @@ from esphome.const import (
 
 from .types import (
     COLOR_MODES,
+    DIMMING_DIRECTIONS,
     LIMIT_MODES,
     AddressableLightState,
     AddressableSet,
@@ -36,6 +37,8 @@ from .types import (
     LightIsOffCondition,
     LightIsOnCondition,
     LightState,
+    StartDimmingAction,
+    StopDimmingAction,
     ToggleAction,
 )
 
@@ -170,6 +173,8 @@ async def light_control_to_code(config, action_id, template_arg, args):
 
 
 CONF_RELATIVE_BRIGHTNESS = "relative_brightness"
+CONF_DIRECTION = "direction"
+CONF_SPEED = "speed"
 LIGHT_DIM_RELATIVE_ACTION_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_ID): cv.use_id(LightState),
@@ -256,6 +261,42 @@ async def light_addressable_set_to_code(config, action_id, template_arg, args):
         templ = await cg.templatable(config[CONF_WHITE], args, cg.float_)
         cg.add(var.set_white(templ))
     return var
+
+
+LIGHT_START_DIMMING_ACTION_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.use_id(LightState),
+        cv.Optional(CONF_DIRECTION, default="UP"): cv.enum(
+            DIMMING_DIRECTIONS, upper=True
+        ),
+        cv.Required(CONF_SPEED): cv.templatable(cv.percentage),
+    }
+)
+
+
+@automation.register_action(
+    "light.start_dimming", StartDimmingAction, LIGHT_START_DIMMING_ACTION_SCHEMA
+)
+async def light_start_dimming_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    templ = await cg.templatable(config[CONF_SPEED], args, float)
+    cg.add(var.set_speed(templ))
+    cg.add(var.set_direction(config[CONF_DIRECTION]))
+    return var
+
+
+LIGHT_STOP_DIMMING_ACTION_SCHEMA = automation.maybe_simple_id(
+    {cv.Required(CONF_ID): cv.use_id(LightState)}
+)
+
+
+@automation.register_action(
+    "light.stop_dimming", StopDimmingAction, LIGHT_STOP_DIMMING_ACTION_SCHEMA
+)
+async def light_stop_dimming_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
 
 
 @automation.register_condition(

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -296,5 +296,15 @@ void LightState::save_remote_values_() {
   this->rtc_.save(&saved);
 }
 
+void LightState::start_dimming(float speed, DimmingDirection direction) {
+  this->transformer_ = make_unique<LightDimmerTransformer>(*this);
+  auto *tr = static_cast<LightDimmerTransformer *>(this->transformer_.get());
+  tr->set_speed(speed);
+  tr->set_direction(direction == DimmingDirection::DIM_UP ? 1 : -1);
+  tr->setup(this->current_values, this->current_values, 0);
+}
+
+void LightState::stop_dimming() { this->set_immediately_(this->current_values, true); }
+
 }  // namespace light
 }  // namespace esphome

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -28,6 +28,11 @@ enum LightRestoreMode : uint8_t {
   LIGHT_RESTORE_AND_ON,
 };
 
+enum class DimmingDirection : uint8_t {
+  DIM_UP,
+  DIM_DOWN,
+};
+
 struct LightStateRTCState {
   LightStateRTCState(ColorMode color_mode, bool state, float brightness, float color_brightness, float red, float green,
                      float blue, float white, float color_temp, float cold_white, float warm_white)
@@ -189,6 +194,12 @@ class LightState : public EntityBase, public Component {
    * }
    */
   bool is_transformer_active();
+
+  /// Start continuously dimming the light.
+  void start_dimming(float speed, DimmingDirection direction);
+
+  /// Stop any active dimming or transition and save current state.
+  void stop_dimming();
 
  protected:
   friend LightOutput;

--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -122,5 +122,40 @@ class LightFlashTransformer : public LightTransformer {
   bool begun_lightstate_restore_;
 };
 
+class LightDimmerTransformer : public LightTransformer {
+ public:
+  LightDimmerTransformer(LightState &state) : state_(state) {}
+
+  void set_speed(float speed) { this->speed_ = speed; }
+  void set_direction(int direction) { this->direction_ = direction; }
+
+  void start() override { this->last_update_ = millis(); }
+
+  optional<LightColorValues> apply() override {
+    uint32_t now = millis();
+    float dt = (now - this->last_update_) / 1000.0f;
+    this->last_update_ = now;
+
+    auto cur = this->state_.current_values;
+    float b = cur.get_brightness() + this->speed_ * dt * this->direction_;
+    b = clamp(b, 0.0f, 1.0f);
+    cur.set_state(b > 0.0f);
+    cur.set_brightness(b);
+    if (b <= 0.0f || b >= 1.0f)
+      this->finished_ = true;
+    this->target_values_ = cur;
+    return cur;
+  }
+
+  bool is_finished() override { return this->finished_; }
+
+ protected:
+  LightState &state_;
+  float speed_{0};
+  int direction_{1};
+  uint32_t last_update_{0};
+  bool finished_{false};
+};
+
 }  // namespace light
 }  // namespace esphome

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -35,11 +35,19 @@ LIMIT_MODES = {
     "DO_NOTHING": LimitMode.DO_NOTHING,
 }
 
+DimmingDirection = light_ns.enum("DimmingDirection", is_class=True)
+DIMMING_DIRECTIONS = {
+    "UP": DimmingDirection.DIM_UP,
+    "DOWN": DimmingDirection.DIM_DOWN,
+}
+
 # Actions
 ToggleAction = light_ns.class_("ToggleAction", automation.Action)
 LightControlAction = light_ns.class_("LightControlAction", automation.Action)
 DimRelativeAction = light_ns.class_("DimRelativeAction", automation.Action)
 AddressableSet = light_ns.class_("AddressableSet", automation.Action)
+StartDimmingAction = light_ns.class_("StartDimmingAction", automation.Action)
+StopDimmingAction = light_ns.class_("StopDimmingAction", automation.Action)
 LightIsOnCondition = light_ns.class_("LightIsOnCondition", automation.Condition)
 LightIsOffCondition = light_ns.class_("LightIsOffCondition", automation.Condition)
 


### PR DESCRIPTION
## Summary
- add `DimmingDirection` enum and public dimming methods
- implement `LightDimmerTransformer` for continuous brightness change
- expose new automation actions `light.start_dimming` and `light.stop_dimming`
- wire Python schema and codegen

## Testing
- `pre-commit run --files esphome/components/light/light_state.h esphome/components/light/light_state.cpp esphome/components/light/transformers.h esphome/components/light/automation.h esphome/components/light/automation.py esphome/components/light/types.py`


------
https://chatgpt.com/codex/tasks/task_e_6871832ffa8c83248992d16c386f8bb5